### PR TITLE
Fix duplicate AuthProvider usage

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,13 +3,8 @@ import ReactDOM from 'react-dom/client';
 import App from '@/App';
 import '@/index.css';
 
-// 👇 Importa el AuthProvider
-import { AuthProvider } from '@/contexts/AuthContext';
-
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <AuthProvider> {/* 👈 Rodea la app con el contexto */}
-      <App />
-    </AuthProvider>
+    <App />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- remove duplicate AuthProvider wrapper in `main.jsx`

## Testing
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68709927165083208c5c70f80a261435