### PR TITLE
Fix toast default props

### DIFF
--- a/src/components/ui/toast.jsx
+++ b/src/components/ui/toast.jsx
@@ -34,7 +34,7 @@ const toastVariants = cva(
 	},
 );
 
-const Toast = React.forwardRef(({ className, variant, ...props }, ref) => {
+const Toast = React.forwardRef(({ className, variant, ...props } = {}, ref) => {
 	return (
 		<ToastPrimitives.Root
 			ref={ref}


### PR DESCRIPTION
## Summary
- fix default params for Toast to avoid destructure error

## Testing
- `npm run build` *(fails: vite Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_6870b64f8f4483209b6c2478acac2b91