### PR TITLE
Improve client creation error handling

### DIFF
--- a/src/components/ClientsPanel.jsx
+++ b/src/components/ClientsPanel.jsx
@@ -64,7 +64,14 @@ export default function ClientsPanel() {
       setEditingClient(null);
       toast({ title: "Éxito", description: `Cliente ${clientData.id ? 'actualizado' : 'creado'} correctamente.` });
     } catch (error) {
-      toast({ title: "Error", description: "No se pudo guardar el cliente.", variant: "destructive" });
+      const { message, code, details } = error || {};
+      const fullMessage =
+        message ||
+        [code, details]
+          .filter(Boolean)
+          .join(' ') ||
+        "No se pudo guardar el cliente.";
+      toast({ title: "Error", description: fullMessage, variant: "destructive" });
     }
   };
 


### PR DESCRIPTION
## Summary
- show Supabase error details when saving a client fails

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687123fcb90c8320bdafaca10a084e06