### PR TITLE
Use role IDs for collaborator roles

### DIFF
--- a/src/components/CollaboratorsPanel.jsx
+++ b/src/components/CollaboratorsPanel.jsx
@@ -115,30 +115,37 @@ import React, { useState, useEffect } from 'react';
         setShowModal(true);
       };
 
-      const handleSaveCollaborator = async (collaboratorData) => {
-        try {
-          if (editingCollaborator) {
-            if (profile && editingCollaborator.user_id === profile.user_id) {
-              await collaboratorsService.updateCurrentUserProfile(collaboratorData);
-              toast({ title: "Perfil actualizado", description: "Tus datos se han actualizado correctamente" });
-            } else {
-              await collaboratorsService.update(editingCollaborator.id, collaboratorData);
-              toast({ title: "Colaborador actualizado", description: "Los datos se han actualizado correctamente" });
-            }
-          } else {
-            await collaboratorsService.create(collaboratorData);
-            toast({ title: "Invitación Enviada", description: "Se ha enviado una invitación por correo al nuevo colaborador." });
-          }
-          setShowModal(false);
-          loadCollaborators();
-        } catch (error) {
-          toast({
-            title: "Error al guardar",
-            description: error.message || "No se pudo guardar la información.",
-            variant: "destructive"
-          });
-        }
-      };
+      const handleSaveCollaborator = async (collaboratorData, roleId) => {
+  try {
+    let saved;
+    if (editingCollaborator) {
+      if (profile && editingCollaborator.user_id === profile.user_id) {
+        saved = await collaboratorsService.updateCurrentUserProfile(collaboratorData);
+        toast({ title: "Perfil actualizado", description: "Tus datos se han actualizado correctamente" });
+      } else {
+        saved = await collaboratorsService.update(editingCollaborator.id, collaboratorData);
+        toast({ title: "Colaborador actualizado", description: "Los datos se han actualizado correctamente" });
+      }
+    } else {
+      saved = await collaboratorsService.create(collaboratorData);
+      toast({ title: "Invitación Enviada", description: "Se ha enviado una invitación por correo al nuevo colaborador." });
+    }
+
+    const collaboratorId = editingCollaborator ? editingCollaborator.id : saved?.id || saved?.collaborator_id || saved?.collaboratorId;
+    if (collaboratorId && roleId) {
+      await collaboratorsService.assignRole(collaboratorId, roleId);
+    }
+
+    setShowModal(false);
+    loadCollaborators();
+  } catch (error) {
+    toast({
+      title: "Error al guardar",
+      description: error.message || "No se pudo guardar la información.",
+      variant: "destructive",
+    });
+  }
+};
 
       const handleCollaboratorAction = (action, collaboratorId) => {
         toast({

--- a/src/components/FreelancersPanel.jsx
+++ b/src/components/FreelancersPanel.jsx
@@ -134,33 +134,39 @@ export default function FreelancersPanel() {
     setShowModal(true);
   };
 
-  const handleSaveCollaborator = async (collaboratorData) => {
-    try {
-      if (editingCollaborator) {
-        await collaboratorsService.update(editingCollaborator.id, collaboratorData);
-        toast({
-          title: "Colaborador actualizado",
-          description: "Los datos se han actualizado correctamente"
-        });
-      } else {
-        await collaboratorsService.create(collaboratorData);
-        toast({
-          title: "Colaborador registrado",
-          description: "El nuevo colaborador se ha agregado al equipo"
-        });
-      }
-      
-      setShowModal(false);
-      setEditingCollaborator(null);
-      loadCollaborators();
-    } catch (error) {
+  const handleSaveCollaborator = async (collaboratorData, roleId) => {
+  try {
+    let saved;
+    if (editingCollaborator) {
+      saved = await collaboratorsService.update(editingCollaborator.id, collaboratorData);
       toast({
-        title: "Error al guardar",
-        description: "No se pudo guardar la información del colaborador",
-        variant: "destructive"
+        title: "Colaborador actualizado",
+        description: "Los datos se han actualizado correctamente"
+      });
+    } else {
+      saved = await collaboratorsService.create(collaboratorData);
+      toast({
+        title: "Colaborador registrado",
+        description: "El nuevo colaborador se ha agregado al equipo"
       });
     }
-  };
+
+    const collaboratorId = editingCollaborator ? editingCollaborator.id : saved?.id || saved?.collaborator_id || saved?.collaboratorId;
+    if (collaboratorId && roleId) {
+      await collaboratorsService.assignRole(collaboratorId, roleId);
+    }
+
+    setShowModal(false);
+    setEditingCollaborator(null);
+    loadCollaborators();
+  } catch (error) {
+    toast({
+      title: "Error al guardar",
+      description: "No se pudo guardar la información del colaborador",
+      variant: "destructive",
+    });
+  }
+};
 
   const handleCollaboratorAction = (action, collaboratorId) => {
     toast({

--- a/src/components/collaborator/CollaboratorModal.jsx
+++ b/src/components/collaborator/CollaboratorModal.jsx
@@ -7,7 +7,7 @@ import CollaboratorFormFields from '@/components/collaborator/form/CollaboratorF
 import InternalCollaboratorFields from '@/components/collaborator/form/InternalCollaboratorFields';
 import FreelancerFields from '@/components/collaborator/form/FreelancerFields';
 import FormActions from '@/components/collaborator/form/FormActions';
-import { ROLES } from '@/lib/permissions';
+import { ROLES, ROLE_ID_MAP } from '@/lib/permissions';
 
 const getInitialFormData = (collaborator) => ({
   name: collaborator?.name || '',
@@ -24,8 +24,8 @@ const getInitialFormData = (collaborator) => ({
   rating: collaborator?.rating || 5.0,
   notes: collaborator?.notes || '',
   is_active: collaborator?.is_active ?? true,
-  role: collaborator?.role || ROLES.FREELANCE,
-});
+    role_id: collaborator?.role_id || ROLE_ID_MAP[collaborator?.role] || ROLE_ID_MAP[ROLES.FREELANCE],
+  });
 
 export default function CollaboratorModal({ show, onClose, collaborator, onSave }) {
   const [formData, setFormData] = useState(getInitialFormData(null));
@@ -89,7 +89,8 @@ export default function CollaboratorModal({ show, onClose, collaborator, onSave 
 
     setSaving(true);
     try {
-      await onSave(formData);
+        const { role_id, ...payload } = formData;
+        await onSave(payload, role_id ? parseInt(role_id, 10) : undefined);
     } catch (error) {
        toast({
         title: "Error al guardar",

--- a/src/components/collaborator/form/CollaboratorFormFields.jsx
+++ b/src/components/collaborator/form/CollaboratorFormFields.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { User, Mail, Phone, MapPin, Camera, Shield } from 'lucide-react';
-import { ROLES } from '@/lib/permissions';
+import { ROLE_ID_MAP } from '@/lib/permissions';
 
 const availabilityOptions = [
   { value: 'disponible', label: 'Disponible' },
@@ -106,17 +106,17 @@ export default function CollaboratorFormFields({ formData, errors, onInputChange
                 <Shield className="w-4 h-4 inline mr-1" />
                 Rol de Usuario *
             </label>
-            <select
-                name="role"
-                value={formData.role}
-                onChange={onInputChange}
-                onBlur={onBlur}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            >
-                {Object.values(ROLES).map(role => (
-                    <option key={role} value={role}>{role}</option>
-                ))}
-            </select>
+              <select
+                  name="role_id"
+                  value={formData.role_id}
+                  onChange={onInputChange}
+                  onBlur={onBlur}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              >
+                  {Object.entries(ROLE_ID_MAP).map(([label, id]) => (
+                      <option key={id} value={id}>{label}</option>
+                  ))}
+              </select>
             <p className="text-xs text-gray-500 mt-1">
               Define los permisos de acceso del usuario en la plataforma.
             </p>

--- a/src/lib/permissions.js
+++ b/src/lib/permissions.js
@@ -7,6 +7,13 @@ export const ROLES = {
   FREELANCE: 'Freelance',
 };
 
+export const ROLE_ID_MAP = {
+  [ROLES.DIRECTOR]: 1,
+  [ROLES.ADMINISTRADOR]: 2,
+  [ROLES.OPERADOR]: 3,
+  [ROLES.FREELANCE]: 4,
+};
+
 export const permissions = {
   [ROLES.DIRECTOR]: {
     canManageUsers: true,

--- a/src/lib/services/collaboratorsService.js
+++ b/src/lib/services/collaboratorsService.js
@@ -106,10 +106,18 @@ import { supabase } from '@/lib/customSupabaseClient';
         if (error) throw error;
       },
 
-      async sendPasswordReset(email) {
-        const { error } = await supabase.auth.resetPasswordForEmail(email, {
-          redirectTo: `${window.location.origin}`,
-        });
-        if (error) throw error;
-      }
-    };
+        async sendPasswordReset(email) {
+          const { error } = await supabase.auth.resetPasswordForEmail(email, {
+            redirectTo: `${window.location.origin}`,
+          });
+          if (error) throw error;
+        },
+
+        async assignRole(collaboratorId, roleId) {
+          const { error } = await supabase.rpc('assign_role_to_collaborator', {
+            collaborator_id: collaboratorId,
+            role_id: roleId,
+          });
+          if (error) throw error;
+        }
+      };


### PR DESCRIPTION
## Summary
- map human-readable roles to numeric role IDs
- store selected role as role_id and strip before saving collaborators
- assign roles via `assign_role_to_collaborator` RPC after create/update

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6896d5d80d048320b3df479cb6e39d42